### PR TITLE
Refactor max_workers calculation to use os.cpu_count

### DIFF
--- a/lories/connectors/tasks/process.py
+++ b/lories/connectors/tasks/process.py
@@ -44,8 +44,10 @@ class ProcessContext(TaskContext):
         self._connectors._add(*(connector.duplicate(context=self._connectors) for connector in connectors))
 
     def _build(self, configs: Configurations) -> Executor:
+        get_cpu_count = getattr(os, "process_cpu_count", os.cpu_count)
+        max_workers_default = max(int((get_cpu_count() or 1) / 2), 1)
         return ProcessPoolExecutor(
-            max_workers=configs.get_int("workers_max", default=max(int((os.cpu_count() or 1) / 2), 1)),
+            max_workers=configs.get_int("workers_max", default=max_workers_default),
             mp_context=self._context,
         )
 

--- a/lories/data/tasks.py
+++ b/lories/data/tasks.py
@@ -56,9 +56,11 @@ class TaskContext(_TaskContext, Activator):
         return self.__executor.submit(fn, *args, **kwargs)
 
     def _build(self, configs: Configurations) -> Executor:
+        cpu_fn = getattr(os, "process_cpu_count", os.cpu_count)
+        max_workers_default = min(32, (cpu_fn() or 1) + 4)
         return ThreadPoolExecutor(
             thread_name_prefix=self._task_prefix,
-            max_workers=configs.get_int("workers_max", default=min(32, (os.process_cpu_count() or 1) + 4)),
+            max_workers=configs.get_int("workers_max", default=max_workers_default),
         )
 
     def activate(self) -> None:

--- a/lories/data/tasks.py
+++ b/lories/data/tasks.py
@@ -56,8 +56,8 @@ class TaskContext(_TaskContext, Activator):
         return self.__executor.submit(fn, *args, **kwargs)
 
     def _build(self, configs: Configurations) -> Executor:
-        cpu_fn = getattr(os, "process_cpu_count", os.cpu_count)
-        max_workers_default = min(32, (cpu_fn() or 1) + 4)
+        get_cpu_count = getattr(os, "process_cpu_count", os.cpu_count)
+        max_workers_default = min(32, (get_cpu_count() or 1) + 4)
         return ThreadPoolExecutor(
             thread_name_prefix=self._task_prefix,
             max_workers=configs.get_int("workers_max", default=max_workers_default),


### PR DESCRIPTION
Hey Adrian,
in Python 3.11 os.process_cpu_count() isn’t available yet, so we’d need to fall back to os.cpu_count() in that case.

Does that approach sound good to you, or would you prefer handling it differently?